### PR TITLE
Get product transactions endpoint

### DIFF
--- a/mongoose_app/models.py
+++ b/mongoose_app/models.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from django.core.validators import MaxValueValidator, MinValueValidator
 #from django.utils.translation import Trans
 
+
 class Category(models.Model):
     name = models.CharField(max_length=30)
     alcoholic = models.BooleanField(default=False)
@@ -91,6 +92,23 @@ class ProductTransactions(models.Model):
 
     class Meta:
         verbose_name_plural = "Products"
+
+
+class NamedTransactionProductTotal(models.Model):
+    name = models.CharField(max_length=60)
+    product_id = models.IntegerField()
+    amount = models.IntegerField()
+
+    class Meta:
+        managed = False
+
+    def serialize(self) -> dict:
+        return {
+            'name': self.name,
+            'id': self.product_id,
+            'amount': self.amount
+        }
+
 
 # Every transaction has at least a link with a user, an id and a sum
 # Whether this sum has a negative or positive influence on the total credit depends on the type of transaction

--- a/mongoose_app/urls.py
+++ b/mongoose_app/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path('card', views.get_card, name='get_card'),
     path('products', views.get_products, name='get_products'),
     path('confirm', views.confirm_card, name='confirm_card'),
+    path('product_transactions', views.get_product_transactions, name="get_product_transactions"),
 
     # POST endpoints
     path('transaction', views.create_transaction, name='create_transaction'),


### PR DESCRIPTION
This PR adds an endpoint to fetch ProductTransactions. queryable with a unix epoch timestamp in seconds.

If `1666811215` is given as the `date` parameter, all transactions on the date `2022-10-26` will be returned:
```json
[
    {
        "name": "Racer 5 India Pale Ale, Bear Republic Bre",
        "id": 25,
        "amount": 6
    },
    {
        "name": "Hummus",
        "id": 23,
        "amount": 1
    }
]
```