### PR TITLE
fix: DEBUG envVar is false by default

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -27,7 +27,8 @@ USER_TOKEN=token
 MAILGUN_ENV=
 MAILGUN_TOKEN=
 
-DEBUG=True
+#Disable DEBUG mode by default. Can be enabled for local development
+DEBUG=False
 
 ALLOWED_HOSTS=
 


### PR DESCRIPTION
debug mode should never be the default, as a sloppy dev can push debug mode to production if not carefull